### PR TITLE
feat: support map as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,13 +161,13 @@ Fields are accessed in a similar way. Assuming `foo` has a field called "Length"
 
 	"foo.Length > 9000"
 
+The values of a `map` are accessed in the same way. Assuming the parameter `foo` is `map[string]int{ "bar": 1 }`
+
+	"foo.bar == 1"
+
 Accessors can be nested to any depth, like the following
 
 	"foo.Bar.Baz.SomeFunction()"
-
-However it is not _currently_ supported to access values in `map`s. So the following will not work
-
-	"foo.SomeMap['key']"
 
 This may be convenient, but note that using accessors involves a _lot_ of reflection. This makes the expression about four times slower than just using a parameter (consult the benchmarks for more precise measurements on your system).
 If at all reasonable, the author recommends extracting the values you care about into a parameter map beforehand, or defining a struct that implements the `Parameters` interface, and which grabs fields as required. If there are functions you want to use, it's better to pass them as expression functions (see the above section). These approaches use no reflection, and are designed to be fast and clean.

--- a/dummies_test.go
+++ b/dummies_test.go
@@ -3,6 +3,7 @@ package govaluate
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 /*
@@ -14,6 +15,7 @@ type dummyParameter struct {
 	BoolFalse bool
 	Nil       interface{}
 	Nested    dummyNestedParameter
+	Map       map[string]interface{}
 }
 
 func (this dummyParameter) Func() string {
@@ -33,9 +35,9 @@ func (this dummyParameter) FuncArgStr(arg1 string) string {
 }
 
 func (this dummyParameter) TestArgs(str string, ui uint, ui8 uint8, ui16 uint16, ui32 uint32, ui64 uint64, i int, i8 int8, i16 int16, i32 int32, i64 int64, f32 float32, f64 float64, b bool) string {
-	
+
 	var sum float64
-	
+
 	sum = float64(ui) + float64(ui8) + float64(ui16) + float64(ui32) + float64(ui64)
 	sum += float64(i) + float64(i8) + float64(i16) + float64(i32) + float64(i64)
 	sum += float64(f32)
@@ -66,6 +68,11 @@ var dummyParameterInstance = dummyParameter{
 	Nil:       nil,
 	Nested: dummyNestedParameter{
 		Funk: "funkalicious",
+	},
+	Map: map[string]interface{}{
+		"String":        "string!",
+		"Int":           101,
+		"StringCompare": strings.Compare,
 	},
 }
 

--- a/evaluationFailure_test.go
+++ b/evaluationFailure_test.go
@@ -34,6 +34,7 @@ const (
 	TOO_FEW_ARGS             = "Too few arguments to parameter call"
 	TOO_MANY_ARGS            = "Too many arguments to parameter call"
 	MISMATCHED_PARAMETERS    = "Argument type conversion failed"
+	UNEXPORTED_ACCESSOR      = "Unable to access unexported"
 )
 
 // preset parameter map of types that can be used in an evaluation failure test to check typing.
@@ -487,6 +488,18 @@ func TestInvalidParameterCalls(test *testing.T) {
 			Input:      "foo.FuncArgStr(5)",
 			Parameters: fooFailureParameters,
 			Expected:   MISMATCHED_PARAMETERS,
+		},
+		EvaluationFailureTest{
+			Name:  "Unexported parameter access",
+			Input: "foo.bar",
+			Parameters: map[string]interface{}{
+				"foo": struct {
+					bar string
+				}{
+					bar: "baz",
+				},
+			},
+			Expected: UNEXPORTED_ACCESSOR,
 		},
 	}
 

--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"unicode"
 )
 
 const (
@@ -331,6 +332,13 @@ func makeAccessorStage(pair []string) evaluationOperator {
 
 			switch coreValue.Kind() {
 			case reflect.Struct:
+				// check if field is exported
+				firstCharacter := getFirstRune(pair[i])
+				if unicode.ToUpper(firstCharacter) != firstCharacter {
+					errorMsg := fmt.Sprintf("Unable to access unexported field '%s' in '%s'", pair[i], pair[i-1])
+					return nil, errors.New(errorMsg)
+				}
+
 				field = coreValue.FieldByName(pair[i])
 				if field != (reflect.Value{}) {
 					value = field.Interface()

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -710,7 +710,7 @@ func TestNoParameterEvaluation(test *testing.T) {
 			Expected: true,
 		},
 		EvaluationTest{
-			
+
 			Name:  "Ternary/Java EL ambiguity",
 			Input: "false ? foo:length()",
 			Functions: map[string]ExpressionFunction{
@@ -1390,6 +1390,20 @@ func TestParameterizedEvaluation(test *testing.T) {
 			Input:      "foo.Nested.Funk",
 			Parameters: []EvaluationParameter{fooParameter},
 			Expected:   "funkalicious",
+		},
+		EvaluationTest{
+
+			Name:       "Nested Map string",
+			Input:      "foo.Map.String",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   "string!",
+		},
+		EvaluationTest{
+
+			Name:       "Nested Map function",
+			Input:      `foo.Map.StringCompare("foo", "bar")`,
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   1.0,
 		},
 		EvaluationTest{
 

--- a/parsing.go
+++ b/parsing.go
@@ -186,17 +186,6 @@ func readToken(stream *lexerStream, state lexerState, functions map[string]Expre
 				kind = ACCESSOR
 				splits := strings.Split(tokenString, ".")
 				tokenValue = splits
-
-				// check that none of them are unexported
-				for i := 1; i < len(splits); i++ {
-
-					firstCharacter := getFirstRune(splits[i])
-
-					if unicode.ToUpper(firstCharacter) != firstCharacter {
-						errorMsg := fmt.Sprintf("Unable to access unexported field '%s' in token '%s'", splits[i], tokenString)
-						return ExpressionToken{}, errors.New(errorMsg), false
-					}
-				}
 			}
 			break
 		}

--- a/parsingFailure_test.go
+++ b/parsingFailure_test.go
@@ -17,7 +17,6 @@ const (
 	INVALID_NUMERIC          = "Unable to parse numeric value"
 	UNDEFINED_FUNCTION       = "Undefined function"
 	HANGING_ACCESSOR         = "Hanging accessor on token"
-	UNEXPORTED_ACCESSOR      = "Unable to access unexported"
 	INVALID_HEX              = "Unable to parse hex value"
 )
 
@@ -177,13 +176,6 @@ func TestParsingFailure(test *testing.T) {
 			Name:     "Hanging accessor",
 			Input:    "foo.Bar.",
 			Expected: HANGING_ACCESSOR,
-		},
-		ParsingFailureTest{
-
-			// this is expected to change once there are structtags in place that allow aliasing of fields
-			Name:     "Unexported parameter access",
-			Input:    "foo.bar",
-			Expected: UNEXPORTED_ACCESSOR,
 		},
 		ParsingFailureTest{
 			Name:     "Incomplete Hex",


### PR DESCRIPTION
related: https://github.com/casbin/casbin/issues/1328

```go
expression, err := NewEvaluableExpression("foo.bar > 0")

parameters := make(map[string]interface{})
parameters["foo"] = map[string]int{
    "bar": -1,
}

result, err := expression.Evaluate(parameters)
// result is now set to "false"
```