### PR TITLE
feat: fix nil pointer panic for type map

### DIFF
--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -355,7 +355,7 @@ func makeAccessorStage(pair []string) evaluationOperator {
 				field = coreValue.MapIndex(reflect.ValueOf(pair[i]))
 				if field != (reflect.Value{}) {
 					inter := field.Interface()
-					if reflect.TypeOf(inter).Kind() == reflect.Func {
+					if inter != nil && reflect.TypeOf(inter).Kind() == reflect.Func {
 						method = reflect.ValueOf(inter)
 					} else {
 						value = inter


### PR DESCRIPTION
In case of one of parameters has map type and its value is nil, script ends up with panic because of checking: `reflect.TypeOf(inter).Kind() == reflect.Func`.