### PR TITLE
feat: support single element array in "IN"

### DIFF
--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -435,11 +435,7 @@ func ensureSliceStage(op evaluationOperator) evaluationOperator {
 		if err != nil {
 			return orig, err
 		}
-		slice, isSlice := orig.([]interface{})
-		if !isSlice {
-			slice = []interface{}{orig}
-		}
-		return slice, nil
+		return []interface{}{orig}, nil
 	}
 }
 

--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -429,6 +429,20 @@ func makeAccessorStage(pair []string) evaluationOperator {
 	}
 }
 
+func ensureSliceStage(op evaluationOperator) evaluationOperator {
+	return func(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+		orig, err := op(left, right, parameters)
+		if err != nil {
+			return orig, err
+		}
+		slice, isSlice := orig.([]interface{})
+		if !isSlice {
+			slice = []interface{}{orig}
+		}
+		return slice, nil
+	}
+}
+
 func separatorStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
 
 	var ret []interface{}

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -507,6 +507,12 @@ func TestNoParameterEvaluation(test *testing.T) {
 		},
 		EvaluationTest{
 
+			Name:     "Single Element Array membership literal",
+			Input:    "1 in (1)",
+			Expected: true,
+		},
+		EvaluationTest{
+
 			Name:     "Logical operator reordering (#30)",
 			Input:    "(true && true) || (true && false)",
 			Expected: true,

--- a/stagePlanner.go
+++ b/stagePlanner.go
@@ -389,10 +389,17 @@ func planValue(stream *tokenStream) (*evaluationStage, error) {
 	switch token.Kind {
 
 	case CLAUSE:
+		prev := stream.tokens[stream.index-2] // todo guard against underflow
 
 		ret, err = planTokens(stream)
 		if err != nil {
 			return nil, err
+		}
+
+		// clauses with single elements don't trigger SEPARATE stage planner
+		// this ensures that when used as part of an "in" comparison, the array requirement passes
+		if prev.Kind == COMPARATOR && prev.Value == "in" && ret.symbol == LITERAL {
+			ret.operator = ensureSliceStage(ret.operator)
 		}
 
 		// advance past the CLAUSE_CLOSE token. We know that it's a CLAUSE_CLOSE, because at parse-time we check for unbalanced parens.

--- a/stagePlanner.go
+++ b/stagePlanner.go
@@ -389,7 +389,10 @@ func planValue(stream *tokenStream) (*evaluationStage, error) {
 	switch token.Kind {
 
 	case CLAUSE:
-		prev := stream.tokens[stream.index-2] // todo guard against underflow
+		var prev ExpressionToken
+		if stream.index > 1 {
+			prev = stream.tokens[stream.index-2]
+		}
 
 		ret, err = planTokens(stream)
 		if err != nil {


### PR DESCRIPTION
Fix: https://github.com/casbin/govaluate/issues/11

The fix is respectfully borrowed from [here](https://github.com/TheDMSGroup/govaluate/commits/in-single-element/).
