### PR TITLE
feat: reduce memory allocs to optimize performance

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -8,7 +8,7 @@ import (
 Serves as a "water test" to give an idea of the general overhead of parsing
 */
 func BenchmarkSingleParse(bench *testing.B) {
-
+	bench.ReportAllocs()
 	for i := 0; i < bench.N; i++ {
 		_, _ = NewEvaluableExpression("1")
 	}
@@ -19,7 +19,7 @@ The most common use case, a single variable, modified slightly, compared to a co
 This is the "expected" use case of govaluate.
 */
 func BenchmarkSimpleParse(bench *testing.B) {
-
+	bench.ReportAllocs()
 	for i := 0; i < bench.N; i++ {
 		_, _ = NewEvaluableExpression("(requests_made * requests_succeeded / 100) >= 90")
 	}
@@ -29,6 +29,7 @@ func BenchmarkSimpleParse(bench *testing.B) {
 Benchmarks all syntax possibilities in one expression.
 */
 func BenchmarkFullParse(bench *testing.B) {
+	bench.ReportAllocs()
 	// represents all the major syntax possibilities.
 	expression := "2 > 1 &&" +
 		"'something' != 'nothing' || " +
@@ -45,7 +46,7 @@ func BenchmarkFullParse(bench *testing.B) {
 Benchmarks the bare-minimum evaluation time
 */
 func BenchmarkEvaluationSingle(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expression, _ := NewEvaluableExpression("1")
 
 	bench.ResetTimer()
@@ -58,7 +59,7 @@ func BenchmarkEvaluationSingle(bench *testing.B) {
 Benchmarks evaluation times of literals (no variables, no modifiers)
 */
 func BenchmarkEvaluationNumericLiteral(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expression, _ := NewEvaluableExpression("(2) > (1)")
 
 	bench.ResetTimer()
@@ -71,7 +72,7 @@ func BenchmarkEvaluationNumericLiteral(bench *testing.B) {
 Benchmarks evaluation times of literals with modifiers
 */
 func BenchmarkEvaluationLiteralModifiers(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expression, _ := NewEvaluableExpression("(2) + (2) == (4)")
 
 	bench.ResetTimer()
@@ -81,7 +82,7 @@ func BenchmarkEvaluationLiteralModifiers(bench *testing.B) {
 }
 
 func BenchmarkEvaluationParameter(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expression, _ := NewEvaluableExpression("requests_made")
 	parameters := map[string]interface{}{
 		"requests_made": 99.0,
@@ -97,7 +98,7 @@ func BenchmarkEvaluationParameter(bench *testing.B) {
 Benchmarks evaluation times of parameters
 */
 func BenchmarkEvaluationParameters(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expression, _ := NewEvaluableExpression("requests_made > requests_succeeded")
 	parameters := map[string]interface{}{
 		"requests_made":      99.0,
@@ -114,7 +115,7 @@ func BenchmarkEvaluationParameters(bench *testing.B) {
 Benchmarks evaluation times of parameters + literals with modifiers
 */
 func BenchmarkEvaluationParametersModifiers(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expression, _ := NewEvaluableExpression("(requests_made * requests_succeeded / 100) >= 90")
 	parameters := map[string]interface{}{
 		"requests_made":      99.0,
@@ -134,6 +135,7 @@ This is largely a canary benchmark to make sure that any syntax additions don't
 unnecessarily bloat the evaluation time.
 */
 func BenchmarkComplexExpression(bench *testing.B) {
+	bench.ReportAllocs()
 	expressionString := "2 > 1 &&" +
 		"'something' != 'nothing' || " +
 		"'2014-01-20' < 'Wed Jul  8 23:07:35 MDT 2015' && " +
@@ -160,6 +162,7 @@ and possible performance pitfalls. This test doesn't aim to be comprehensive aga
 it is primarily concerned with tracking how much longer it takes to compile a regex at evaluation-time than during parse-time.
 */
 func BenchmarkRegexExpression(bench *testing.B) {
+	bench.ReportAllocs()
 	expressionString := "(foo !~ bar) && (foobar =~ oba)"
 
 	expression, _ := NewEvaluableExpression(expressionString)
@@ -182,7 +185,7 @@ are actually being precompiled.
 Also demonstrates that (generally) compiling a regex at evaluation-time takes an order of magnitude more time than pre-compiling.
 */
 func BenchmarkConstantRegexExpression(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expressionString := "(foo !~ '[bB]az') && (bar =~ '[bB]ar')"
 	expression, _ := NewEvaluableExpression(expressionString)
 
@@ -198,7 +201,7 @@ func BenchmarkConstantRegexExpression(bench *testing.B) {
 }
 
 func BenchmarkAccessors(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expressionString := "foo.Int"
 	expression, _ := NewEvaluableExpression(expressionString)
 
@@ -209,7 +212,7 @@ func BenchmarkAccessors(bench *testing.B) {
 }
 
 func BenchmarkAccessorMethod(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expressionString := "foo.Func()"
 	expression, _ := NewEvaluableExpression(expressionString)
 
@@ -220,7 +223,7 @@ func BenchmarkAccessorMethod(bench *testing.B) {
 }
 
 func BenchmarkAccessorMethodParams(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expressionString := "foo.FuncArgStr('bonk')"
 	expression, _ := NewEvaluableExpression(expressionString)
 
@@ -231,7 +234,7 @@ func BenchmarkAccessorMethodParams(bench *testing.B) {
 }
 
 func BenchmarkNestedAccessors(bench *testing.B) {
-
+	bench.ReportAllocs()
 	expressionString := "foo.Nested.Funk"
 	expression, _ := NewEvaluableExpression(expressionString)
 

--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -184,7 +184,7 @@ func regexStage(left interface{}, right interface{}, parameters Parameters) (int
 		pattern = right
 	}
 
-	return pattern.Match([]byte(left.(string))), nil
+	return pattern.MatchString(left.(string)), nil
 }
 
 func notRegexStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {

--- a/stagePlanner.go
+++ b/stagePlanner.go
@@ -186,6 +186,7 @@ func planStages(tokens []ExpressionToken) (*evaluationStage, error) {
 	if err != nil {
 		return nil, err
 	}
+	stream.close()
 
 	// while we're now fully-planned, we now need to re-order same-precedence operators.
 	// this could probably be avoided with a different planning method

--- a/tokenStream.go
+++ b/tokenStream.go
@@ -1,30 +1,43 @@
 package govaluate
 
+import "sync"
+
 type tokenStream struct {
 	tokens      []ExpressionToken
 	index       int
 	tokenLength int
 }
 
+var tokenStreamPool = sync.Pool{
+	New: func() interface{} {
+		return new(tokenStream)
+	},
+}
+
 func newTokenStream(tokens []ExpressionToken) *tokenStream {
-	ret := new(tokenStream)
+	ret := tokenStreamPool.Get().(*tokenStream)
 	ret.tokens = tokens
+	ret.index = 0
 	ret.tokenLength = len(tokens)
 	return ret
 }
 
-func (this *tokenStream) rewind() {
-	this.index -= 1
+func (t *tokenStream) rewind() {
+	t.index -= 1
 }
 
-func (this *tokenStream) next() ExpressionToken {
-	token := this.tokens[this.index]
+func (t *tokenStream) next() ExpressionToken {
+	token := t.tokens[t.index]
 
-	this.index += 1
+	t.index += 1
 	return token
 }
 
-func (this tokenStream) hasNext() bool {
+func (t tokenStream) hasNext() bool {
 
-	return this.index < this.tokenLength
+	return t.index < t.tokenLength
+}
+
+func (t *tokenStream) close() {
+	tokenStreamPool.Put(t)
 }


### PR DESCRIPTION
Benchstat comparison of before and after. The only things showing + are down in the nanosecond range and well within the noise ratio. This basically does what it can to get rid of as many allocs as possible which helps to increase the speed.
goos: linux
goarch: amd64
pkg: github.com/casbin/govaluate
cpu: 13th Gen Intel(R) Core(TM) i7-13700H
                                 │   old.txt   │               new.txt                │
                                 │   sec/op    │    sec/op     vs base                │
SingleParse-20                     626.5n ± 4%   601.0n ±  3%   -4.08% (p=0.035 n=10)
SimpleParse-20                     4.110µ ± 3%   3.414µ ±  5%  -16.95% (p=0.000 n=10)
FullParse-20                       19.64µ ± 4%   12.91µ ± 10%  -34.30% (p=0.000 n=10)
EvaluationSingle-20                13.31n ± 5%   13.86n ± 12%   +4.09% (p=0.043 n=10)
EvaluationNumericLiteral-20        49.12n ± 2%   51.68n ±  3%   +5.19% (p=0.000 n=10)
EvaluationLiteralModifiers-20      116.8n ± 2%   130.4n ± 15%  +11.69% (p=0.000 n=10)
EvaluationParameter-20             45.04n ± 3%   37.70n ± 10%  -16.30% (p=0.000 n=10)
EvaluationParameters-20            78.52n ± 1%   69.56n ± 14%  -11.42% (p=0.030 n=10)
EvaluationParametersModifiers-20   167.3n ± 2%   161.1n ±  2%   -3.74% (p=0.000 n=10)
ComplexExpression-20               42.28n ± 3%   33.97n ±  1%  -19.65% (p=0.000 n=10)
RegexExpression-20                 1.320µ ± 1%   1.252µ ±  3%   -5.15% (p=0.000 n=10)
ConstantRegexExpression-20         384.4n ± 3%   310.2n ±  8%  -19.29% (p=0.000 n=10)
Accessors-20                       142.2n ± 3%   127.7n ±  4%  -10.23% (p=0.015 n=10)
AccessorMethod-20                  788.7n ± 2%   800.6n ±  2%   +1.51% (p=0.041 n=10)
AccessorMethodParams-20            906.3n ± 2%   911.8n ±  2%        ~ (p=0.353 n=10)
NestedAccessors-20                 199.4n ± 2%   194.1n ±  3%   -2.68% (p=0.009 n=10)
geomean                            273.7n        251.1n         -8.28%