### PR TITLE
test example

### DIFF
--- a/EvaluableExpression_test.go
+++ b/EvaluableExpression_test.go
@@ -1,0 +1,23 @@
+package govaluate
+
+import "testing"
+
+func TestA(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewEvaluableExpression("foo == 5")
+
+	if err != nil {
+		t.Fatalf("Error creating expression: %v", err)
+	}
+}
+
+func TestB(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewEvaluableExpression("foo == 1")
+
+	if err != nil {
+		t.Fatalf("Error creating expression: %v", err)
+	}
+}

--- a/parsing.go
+++ b/parsing.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	averageTokens = 1
+	samplesMu     = sync.Mutex{}
 	samples       = make([]int, 0, 10)
 )
 
@@ -50,6 +51,7 @@ func parseTokens(expression string, functions map[string]ExpressionFunction) ([]
 		ret = append(ret, token)
 	}
 	stream.close()
+	samplesMu.Lock()
 	if len(samples) == cap(samples) {
 		copy(samples, samples[1:])
 		samples[len(samples)-1] = len(ret)
@@ -61,6 +63,7 @@ func parseTokens(expression string, functions map[string]ExpressionFunction) ([]
 		total += val
 	}
 	averageTokens = total / len(samples)
+	samplesMu.Unlock()
 
 	err = checkBalance(ret)
 	if err != nil {


### PR DESCRIPTION
This is an example of failing tests.
If I ran `go test ./... -race` the data race will be detected.

```
WARNING: DATA RACE
Read at 0x00c0000160f8 by goroutine 6:
  runtime.slicecopy()
      /usr/local/go/src/runtime/slice.go:355 +0x0
  github.com/casbin/govaluate.parseTokens()
      /xxx/tmp/govaluate/parsing.go:54 +0x3cc
  github.com/casbin/govaluate.NewEvaluableExpressionWithFunctions()
      /xxx/tmp/govaluate/EvaluableExpression.go:100 +0xb4
  github.com/casbin/govaluate.NewEvaluableExpression()
      /xxx/tmp/govaluate/EvaluableExpression.go:48 +0x94
  github.com/casbin/govaluate.TestA()
      /xxx/tmp/govaluate/EvaluableExpression_test.go:8 +0x34
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x40

Previous write at 0x00c0000160f8 by goroutine 7:
  runtime.slicecopy()
      /usr/local/go/src/runtime/slice.go:355 +0x0
  github.com/casbin/govaluate.parseTokens()
      /xxx/tmp/govaluate/parsing.go:54 +0x3cc
  github.com/casbin/govaluate.NewEvaluableExpressionWithFunctions()
      /xxx/tmp/govaluate/EvaluableExpression.go:100 +0xb4
  github.com/casbin/govaluate.NewEvaluableExpression()
      /xxx/tmp/govaluate/EvaluableExpression.go:48 +0x94
  github.com/casbin/govaluate.TestB()
      /xxx/tmp/govaluate/EvaluableExpression_test.go:18 +0x34
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x40

Goroutine 6 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1743 +0x5e0
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2168 +0x80
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x184
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2166 +0x6e0
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2034 +0xb74
  main.main()
      _testmain.go:151 +0x110

Goroutine 7 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1743 +0x5e0
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2168 +0x80
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x184
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2166 +0x6e0
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2034 +0xb74
  main.main()
      _testmain.go:151 +0x110
```