### PR TITLE
feat: Add Sample Locking + Massive Parallel test

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -20,7 +20,9 @@ var (
 )
 
 func parseTokens(expression string, functions map[string]ExpressionFunction) ([]ExpressionToken, error) {
+	samplesMu.Lock()
 	ret := make([]ExpressionToken, 0, averageTokens)
+	samplesMu.Unlock()
 	var token ExpressionToken
 	var stream *lexerStream
 	var state lexerState

--- a/parsing.go
+++ b/parsing.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	averageTokens = 1
+	samplesMu     = sync.Mutex{}
 	samples       = make([]int, 0, 10)
 )
 
@@ -50,6 +51,7 @@ func parseTokens(expression string, functions map[string]ExpressionFunction) ([]
 		ret = append(ret, token)
 	}
 	stream.close()
+	samplesMu.Lock()
 	if len(samples) == cap(samples) {
 		copy(samples, samples[1:])
 		samples[len(samples)-1] = len(ret)
@@ -61,6 +63,7 @@ func parseTokens(expression string, functions map[string]ExpressionFunction) ([]
 		total += val
 	}
 	averageTokens = total / len(samples)
+	samplesMu.Unlock()
 
 	err = checkBalance(ret)
 	if err != nil {

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 	"unicode"
@@ -1665,4 +1666,44 @@ func runTokenParsingTest(tokenParsingTests []TokenParsingTest, test *testing.T) 
 
 func noop(arguments ...interface{}) (interface{}, error) {
 	return nil, nil
+}
+
+func TestParallelParsing(t *testing.T) {
+	// This test is to ensure that the parser is thread-safe.
+	// It runs a number of parsing tests in parallel, and checks that they all pass.
+
+	var wg sync.WaitGroup
+
+	tokenParsingTests := []TokenParsingTest{
+		TokenParsingTest{
+			Name:  "Simple expression",
+			Input: "1 + 1",
+			Expected: []ExpressionToken{
+				ExpressionToken{
+					Kind:  NUMERIC,
+					Value: 1.0,
+				},
+				ExpressionToken{
+					Kind:  MODIFIER,
+					Value: "+",
+				},
+				ExpressionToken{
+					Kind:  NUMERIC,
+					Value: 1.0,
+				},
+			},
+		},
+	}
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				runTokenParsingTest(tokenParsingTests, t)
+			}
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
I've added locking around the samples slice to avoid any race conditions. I could not cause the existing code to fail in anyway so I'm not really sure what the issue with the race condition was, but this should solve it. 