### PR TITLE
feat: fix handling multi-byte characters both before and after single byte

### DIFF
--- a/lexerStream.go
+++ b/lexerStream.go
@@ -53,7 +53,7 @@ func (this *lexerStream) rewind(amount int) {
 			this.position -= 1
 			continue
 		}
-		strAmount += utf8.RuneLen(this.source[this.position])
+		strAmount += utf8.RuneLen(this.source[this.position-1])
 		this.position -= 1
 	}
 	this.strPosition -= strAmount

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -944,6 +944,63 @@ func TestComparatorParsing(test *testing.T) {
 	}
 
 	tokenParsingTests = combineWhitespaceExpressions(tokenParsingTests)
+	// The white space actually matters for this test...
+	tokenParsingTests = append(tokenParsingTests, TokenParsingTest{
+		Name:  "Cyrilic characters Array membership",
+		Input: `!(переменная IN ("Н11", "Н12","Н13","Н14"))`,
+		Expected: []ExpressionToken{
+			{
+				Kind:  PREFIX,
+				Value: "!",
+			},
+			{
+				Kind: CLAUSE,
+			},
+			{
+				Kind:  VARIABLE,
+				Value: "переменная",
+			},
+			{
+				Kind:  COMPARATOR,
+				Value: "in",
+			},
+			{
+				Kind: CLAUSE,
+			},
+			{
+				Kind:  STRING,
+				Value: "Н11",
+			},
+			{
+				Kind: SEPARATOR,
+			},
+			{
+				Kind:  STRING,
+				Value: "Н12",
+			},
+			{
+				Kind: SEPARATOR,
+			},
+			{
+				Kind:  STRING,
+				Value: "Н13",
+			},
+			{
+				Kind: SEPARATOR,
+			},
+			{
+				Kind:  STRING,
+				Value: "Н14",
+			},
+			{
+				Kind: CLAUSE_CLOSE,
+			},
+			{
+				Kind: CLAUSE_CLOSE,
+			},
+		},
+	},
+	)
 	runTokenParsingTest(tokenParsingTests, test)
 }
 


### PR DESCRIPTION
Fix: https://github.com/casbin/govaluate/issues/18

Also adds a test so we don't have this type of failure again. 