### PR TITLE
feat: add optional caching of params and constants

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,75 @@
+//go:build go1.24 && cache
+
+package govaluate
+
+import (
+	"sync"
+	"weak"
+)
+
+var (
+	paramMap = sync.Map{}
+
+	constMap = sync.Map{}
+)
+
+func getParameterStage(name string) (*evaluationStage, error) {
+	stage, ok := getParamFromMap(name)
+	if ok {
+		return stage, nil
+	}
+
+	operator := makeParameterStage(name)
+	ret := &evaluationStage{
+		operator: operator,
+	}
+	storeVal := weak.Make(ret)
+	paramMap.Store(name, storeVal)
+	return ret, nil
+}
+
+func getParamFromMap(name string) (*evaluationStage, bool) {
+	stage, ok := paramMap.Load(name)
+	if ok {
+		ptr, ok := stage.(weak.Pointer[evaluationStage])
+		if ok {
+			ret := ptr.Value()
+			if ret != nil {
+				return ret, true
+			}
+			paramMap.Delete(name)
+		}
+	}
+	return nil, false
+}
+
+func getConstantStage(value any) (*evaluationStage, error) {
+	stage, ok := getConstantFromMap(value)
+	if ok {
+		return stage, nil
+	}
+
+	operator := makeLiteralStage(value)
+	ret := &evaluationStage{
+		symbol:   LITERAL,
+		operator: operator,
+	}
+	storeVal := weak.Make(ret)
+	constMap.Store(value, storeVal)
+	return ret, nil
+}
+
+func getConstantFromMap(value any) (*evaluationStage, bool) {
+	stage, ok := constMap.Load(value)
+	if ok {
+		ptr, ok := stage.(weak.Pointer[evaluationStage])
+		if ok {
+			ret := ptr.Value()
+			if ret != nil {
+				return ret, true
+			}
+			constMap.Delete(value)
+		}
+	}
+	return nil, false
+}

--- a/noCache.go
+++ b/noCache.go
@@ -1,0 +1,18 @@
+//go:build !go1.24 || !cache
+
+package govaluate
+
+func getParameterStage(name string) (*evaluationStage, error) {
+	operator := makeParameterStage(name)
+	return &evaluationStage{
+		operator: operator,
+	}, nil
+}
+
+func getConstantStage(value interface{}) (*evaluationStage, error) {
+	operator := makeLiteralStage(value)
+	return &evaluationStage{
+		symbol:   LITERAL,
+		operator: operator,
+	}, nil
+}


### PR DESCRIPTION
If you have a bunch of govaluate expressions kept in memory with similar parameters and/or similar constants this allows you to turn on a cache with a build tag (assuming you have golang 1.24 or greater). This reduces the amount of memory the expressions consume by sharing stages across expressions.

Benchmarks without cache:
```
BenchmarkSingleParse-24                          4112127               289.5 ns/op           224 B/op          6 allocs/op
BenchmarkSimpleParse-24                           709797              1628 ns/op            1211 B/op         29 allocs/op
BenchmarkFullParse-24                             209383              6999 ns/op            4687 B/op        116 allocs/op
BenchmarkEvaluationSingle-24                    128901000                8.998 ns/op           0 B/op          0 allocs/op
BenchmarkEvaluationNumericLiteral-24            43751962                25.94 ns/op            0 B/op          0 allocs/op
BenchmarkEvaluationLiteralModifiers-24          17263702                71.93 ns/op            8 B/op          1 allocs/op
BenchmarkEvaluationParameter-24                 76307056                16.52 ns/op            0 B/op          0 allocs/op
BenchmarkEvaluationParameters-24                37903912                35.15 ns/op            0 B/op          0 allocs/op
BenchmarkEvaluationParametersModifiers-24       10787078                99.12 ns/op           16 B/op          2 allocs/op
BenchmarkComplexExpression-24                   71083309                17.57 ns/op            0 B/op          0 allocs/op
BenchmarkRegexExpression-24                      1591404               762.6 ns/op          1428 B/op         18 allocs/op
BenchmarkConstantRegexExpression-24              8835997               187.5 ns/op             0 B/op          0 allocs/op
BenchmarkAccessors-24                           14347064                75.44 ns/op            8 B/op          1 allocs/op
BenchmarkAccessorMethod-24                       3005412               407.0 ns/op           168 B/op          7 allocs/op
BenchmarkAccessorMethodParams-24                 2729622               464.5 ns/op           208 B/op          8 allocs/op
BenchmarkNestedAccessors-24                     11189446               100.7 ns/op             0 B/op          0 allocs/op
```

Benchmarks with cache:
```
BenchmarkSingleParse-24                          4696720               259.4 ns/op           120 B/op          4 allocs/op
BenchmarkSimpleParse-24                           744771              1548 ns/op             794 B/op         21 allocs/op
BenchmarkFullParse-24                             220964              7149 ns/op            3226 B/op         88 allocs/op
BenchmarkEvaluationSingle-24                    100000000               10.97 ns/op            0 B/op          0 allocs/op
BenchmarkEvaluationNumericLiteral-24            31738222                38.02 ns/op            0 B/op          0 allocs/op
BenchmarkEvaluationLiteralModifiers-24          13775227                85.30 ns/op            8 B/op          1 allocs/op
BenchmarkEvaluationParameter-24                 41696491                28.30 ns/op            0 B/op          0 allocs/op
BenchmarkEvaluationParameters-24                22658908                53.23 ns/op            0 B/op          0 allocs/op
BenchmarkEvaluationParametersModifiers-24       10979146               108.7 ns/op            16 B/op          2 allocs/op
BenchmarkComplexExpression-24                   52387562                22.92 ns/op            0 B/op          0 allocs/op
BenchmarkRegexExpression-24                      1585320               757.0 ns/op          1431 B/op         18 allocs/op
BenchmarkConstantRegexExpression-24              5570799               212.2 ns/op             0 B/op          0 allocs/op
BenchmarkAccessors-24                           14245064                83.62 ns/op            8 B/op          1 allocs/op
BenchmarkAccessorMethod-24                       2444245               483.7 ns/op           168 B/op          7 allocs/op
BenchmarkAccessorMethodParams-24                 2501234               485.1 ns/op           208 B/op          8 allocs/op
BenchmarkNestedAccessors-24                     10499632               114.6 ns/op             0 B/op          0 allocs/op
```